### PR TITLE
Allow label to wrap the input element

### DIFF
--- a/placeholder_polyfill.jquery.js
+++ b/placeholder_polyfill.jquery.js
@@ -54,11 +54,12 @@
                 text = input.attr('placeholder'),
                 id = input.attr('id'),
                 label,placeholder,titleNeeded;
-            if(!id){
+            label = input.closest('label')[0];
+            if(!label && !id){
                 log('the input element with the placeholder needs an id!');
                 return;
             }
-            label = $('label[for="'+id+'"]');
+            label = label || $('label[for="'+id+'"]');
             if(!label){
                 log('the input element with the placeholder needs a label!');
                 return;


### PR DESCRIPTION
It's perfectly valid for a label to wrap the input it labels and not have a for attribute (so no id is needed on the input).

I'm wondering why the label is needed at all though...
