### PR TITLE
fix for issue 6

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -101,6 +101,7 @@
             if(polyfilled.length) {
                 //log('the input element already has a polyfilled placeholder!');
                 positionPlaceholder(polyfilled,input);
+                polyfilled.text(text);
                 return input;
             }
             


### PR DESCRIPTION
on a rerun, input.removeAttr('placeholder'); empties the text in the placeholder span, this restores it
