### PR TITLE
Fix mangled placeholder (raw html needs escaping)

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -110,7 +110,7 @@
                      .addClass(o.options.hiddenOverrideClass);
             }
 
-            placeholder = $('<span class="'+o.options.className+'">'+text+'</span>').appendTo(label);
+            placeholder = $('<span>').addClass(o.options.className).text(text).appendTo(label);
 
             titleNeeded = (placeholder.width() > input.width());
             if(titleNeeded){


### PR DESCRIPTION
When constructing html, variables must always be escaped.
Alternatively, don't construct html but set properties
directly so that escaping is not needed.

If text contained any special characters those were mangled as they
were interpreted as HTML instead of a string (.attr() returns the text,
not the HTML).

Also, depending on what this is run on, this can very well be a security vulnerability (e.g. a page created by a user-input system that sanitizes input but allows placeholders (which are safe on their own)), then this script interprets it as raw HTML. 
