### PR TITLE
Adds the indication that labels are required

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -51,7 +51,7 @@ USAGE:
 		<script src="placeholder_polyfill.jquery.min.combo.js" charset="utf-8"></script>
 	</head>
 
-
+Please bear in mind that every input needs a linked label in order for the plugin to work.
 
 ### Using [Modernizr](http://www.modernizr.com/), modern browser don't even have to load the polyfill at all.
 


### PR DESCRIPTION
I came across this issue while testing HTML5-placeholder-polyfill on a local meaningless file (so, without thinking about accessibility), and lost some time looking for the problem.

Then I found the reason, and Github issue #2. I understand your position, but I think it is necessary to point that out in the Readme file.
