### PR TITLE
jquery plugin - fix polyfill triggering on Firefox MAC when not needed

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -200,7 +200,7 @@
             log('placeholder:abort because autoInit is off');
             return;
         }
-        if('placeholder' in $('<input>')[0] && !config.forceApply){ // don't run the polyfill when the browser has native support
+        if(('placeholder' in $('<input>')[0] || 'placeHolder' in $('<input>')[0]) && !config.forceApply){ // don't run the polyfill when the browser has native support
             log('placeholder:abort because browser has native support');
             return;
         }


### PR DESCRIPTION
fix polyfill triggering on Firefox MAC when not needed. The attribute is named "placeHolder" instead of "placeholder". The condition to trigger or not the polyfill wasn't testing this possibility.

I haven't compiled the src file. Someone with a grunt setup can do it.
