### PR TITLE
Insert a label node with Javascript when no label if found

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -1,7 +1,7 @@
 /**
 * HTML5 placeholder polyfill
 * @requires jQuery - tested with 1.6.2 but might as well work with older versions
-* 
+*
 * code: https://github.com/ginader/HTML5-placeholder-polyfill
 * please report issues at: https://github.com/ginader/HTML5-placeholder-polyfill/issues
 *
@@ -11,7 +11,7 @@
 * http://www.gnu.org/licenses/gpl.html
 *
 * Version: 2.0.6
-* 
+*
 */
 
 (function($) {
@@ -107,14 +107,17 @@
             }
             label = input.closest('label');
             input.removeAttr('placeholder');
-            if(!label.length && !id){
+            // AN ID IS REQUIRED
+            if(!id){
                 log('the input element with the placeholder needs an id!');
                 return;
             }
-            label = label.length ? label : $('label[for="'+id+'"]').first();
+            // SEARCH THE LABEL BY ITS 'for' ATTRIBUTE
+            if(!label.length) label = label.length ? label : $('label[for="'+id+'"]').first();
+            // INSERT LABEL WHEN STILL NOT FOUND
             if(!label.length){
-                log('the input element with the placeholder needs a label!');
-                return;
+                label = $('<label/>',{'for':id, css: {margin:0,height:0}});
+                input.before(label);
             }
             polyfilled = $(label).find('.placeholder');
             if(polyfilled.length) {
@@ -123,7 +126,7 @@
                 polyfilled.text(text);
                 return input;
             }
-            
+
             if(label.hasClass(o.options.removeLabelClass)){
                 label.removeClass(o.options.removeLabelClass)
                      .addClass(o.options.hiddenOverrideClass);
@@ -175,14 +178,14 @@
                 $.attrHooks.placeholder = {
                     get: function(elem) {
                         if (elem.nodeName.toLowerCase() === 'input' || elem.nodeName.toLowerCase() === 'textarea') {
-                            if( $(elem).data('placeholder') ){ 
+                            if( $(elem).data('placeholder') ){
                                 // has been polyfilled
                                 return $( $(elem).data('placeholder') ).text();
                             }else{
                                 // native / not yet polyfilled
                                 return $(elem)[0].placeholder;
                             }
-                            
+
                         }else{
                             return undefined;
                         }
@@ -194,7 +197,7 @@
             }
         });
 
-    
+
 
     };
     $(function(){


### PR DESCRIPTION
I didn't want to add unnecessary label node thus made a small tweak which inserts them when needed. My case was a login screen with just placeholders and no labels. The height and margin settings are to ensure the layout stays unchanged when label-nodes have been inserted.
