### PR TITLE
If input already has focus when placeHolder method run, execute focus-handling code

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -102,6 +102,15 @@
                 text = input.attr('placeholder'),
                 id = input.attr('id'),
                 label,placeholder,titleNeeded,polyfilled;
+
+            function onFocusIn() {
+                if(!o.options.hideOnFocus && window.requestAnimationFrame){
+                    startFilledCheckChange(input,o.options);
+                }else{
+                    hidePlaceholder(input,o.options);
+                }
+            }
+
             if(text === "" || text === undefined) {
               text = input[0].attributes["placeholder"].value;
             }
@@ -141,13 +150,7 @@
             placeholder.click(function(){
                 $(this).data('input').focus();
             });
-            input.focusin(function() {
-                if(!o.options.hideOnFocus && window.requestAnimationFrame){
-                    startFilledCheckChange(input,o.options);
-                }else{
-                    hidePlaceholder(input,o.options);
-                }
-            });
+            input.focusin(onFocusIn);
             input.focusout(function(){
                 showPlaceholderIfEmpty($(this),o.options);
                 if(!o.options.hideOnFocus && window.cancelAnimationFrame){
@@ -191,6 +194,10 @@
                         return $( $(elem).data('placeholder') ).text(value);
                     }
                 };
+            }
+
+            if (input.is(":focus")) {
+                onFocusIn();
             }
         });
 


### PR DESCRIPTION
If jQuery.fn.placeHolder is executed on a jQuery set that contains an element with focus, execute the focus-handling code.

This patch handles scenarios in which a DOM structure is created on-the-fly and then some post-render callback applies the polyfill. If one of the elements in the DOM already has focus, the placeholder text will display on top of the cursor and won't disappear as the user types.
