### PR TITLE
Bugfix: placeholder element must save a reference to the input element in data-input, not to itself.

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -142,7 +142,7 @@
             }
             positionPlaceholder(placeholder,input);
             input.data('placeholder',placeholder);
-            placeholder.data('input',placeholder);
+            placeholder.data('input',input);
             placeholder.click(function(){
                 $(this).data('input').focus();
             });


### PR DESCRIPTION
I suppose is a mistake: placeholder element was saving a reference to itself as data-input instead of a reference to the input element.
Thats affect only to the click handler on placeholder element that auto-focus its related input.
