### PR TITLE
Listen to resize and fontresize on window, not document.

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -94,7 +94,7 @@
             var input = $(this),
                 text = input.attr('placeholder'),
                 id = input.attr('id'),
-                label,placeholder,titleNeeded,polyfilled;
+                label,placeholder,titleNeeded,polyfilled,timerId;
 
             function onFocusIn() {
                 if(!o.options.hideOnFocus && window.requestAnimationFrame){
@@ -152,8 +152,11 @@
             showPlaceholderIfEmpty(input,o.options);
 
             // reformat on window resize and optional reformat on font resize - requires: http://www.tomdeater.com/jquery/onfontresize/
-            $(document).bind("fontresize resize", function(){
-                positionPlaceholder(placeholder,input);
+            $(window).bind("fontresize resize", function(){
+                if (timerId) clearTimeout(timerId);
+                timerId = setTimeout(function() {
+                    positionPlaceholder(placeholder,input);
+                }, 500);
             });
 
             // optional reformat when a textarea is being resized - requires http://benalman.com/projects/jquery-resize-plugin/


### PR DESCRIPTION
This is basically the code from @MarcusPope's issue: https://github.com/ginader/HTML5-placeholder-polyfill/issues/31

We had the same issue in IE8 with jQuery 1.9 as others reported, and this resolved it (along with including jquery.browser to replace that functionality which was removed in jQuery 1.9)

I've not tested this on a huge range of browsers however, as I don't have access to them, but from what Browserstack gives me access to, it looks good.
