### PR TITLE
Check for `cancelAnimationFrame` when we call it.

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -1,7 +1,7 @@
 /**
 * HTML5 placeholder polyfill
 * @requires jQuery - tested with 1.6.2 but might as well work with older versions
-* 
+*
 * code: https://github.com/ginader/HTML5-placeholder-polyfill
 * please report issues at: https://github.com/ginader/HTML5-placeholder-polyfill/issues
 *
@@ -9,7 +9,7 @@
 * Dual licensed under the MIT and GPL licenses:
 * http://www.opensource.org/licenses/mit-license.php
 * http://www.gnu.org/licenses/gpl.html
-* 
+*
 */
 
 (function($) {
@@ -65,7 +65,9 @@
         }());
     }
     function stopCheckChange(){
-        cancelAnimationFrame(animId);
+        if (window.cancelAnimationFrame) {
+          cancelAnimationFrame(animId);
+        }
     }
     function log(msg){
         if(debug && window.console && window.console.log){
@@ -145,7 +147,7 @@
             input.focusin(onFocusIn);
             input.focusout(function(){
                 showPlaceholderIfEmpty($(this),o.options);
-                if(!o.options.hideOnFocus && window.cancelAnimationFrame){
+                if(!o.options.hideOnFocus){
                     stopCheckChange();
                 }
             });


### PR DESCRIPTION
`stopCheckChange()` is called twice, and in [one](https://github.com/ginader/HTML5-placeholder-polyfill/blob/5805e4d11cd8790cf0af422fb487df5a61dc81e3/src/placeholder_polyfill.jquery.js#L56) instance, it isn't checking for `window.cancelAnimationFrame` first.
