### PR TITLE
Eliminate JSHint warnings

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -163,11 +163,11 @@
             // optional reformat when a textarea is being resized - requires http://benalman.com/projects/jquery-resize-plugin/
             if($.event.special.resize){
                 $('textarea').bind('resize', function(event){
-					if ($(this).is(':visible')) {
-						positionPlaceholder(placeholder,input);
-					}
-					event.stopPropagation();
-					event.preventDefault();
+                    if ($(this).is(':visible')) {
+                        positionPlaceholder(placeholder,input);
+                    }
+                    event.stopPropagation();
+                    event.preventDefault();
                 });
             }else{
                 // we simply disable the resizeablilty of textareas when we can't react on them resizing


### PR DESCRIPTION
No logic changes. Fix spaces, tabs and quotes. Apply code advices from JSHint.
