### PR TITLE
fix already-polyfilled classname bug

### DIFF
--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -120,7 +120,7 @@
                 log('the input element with the placeholder needs a label!');
                 return;
             }
-            polyfilled = $(label).find('.placeholder');
+            polyfilled = $(label).find('.' + o.options.className);
             if(polyfilled.length) {
                 //log('the input element already has a polyfilled placeholder!');
                 positionPlaceholder(polyfilled,input);


### PR DESCRIPTION
This fixes an instance where the `className` option was being ignored, resulting in new `<span>`s being created every time `$(input).placeHolder()` was called.
