### PR TITLE
Add change event listener to hide placeholder when e.g. a password manager fills the form

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-uglify": "~0.1.2",
+    "grunt-contrib-uglify": "~0.8.0",
     "grunt-contrib-watch": "~0.3.1",
     "grunt-contrib-concat": "~0.1.3",
     "grunt-remove-logging": "~0.1.0",

--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -151,6 +151,9 @@
                     stopCheckChange();
                 }
             });
+            input.change(function(){
+                showPlaceholderIfEmpty($(this),o.options);
+            });
             showPlaceholderIfEmpty(input,o.options);
 
             // reformat on window resize and optional reformat on font resize - requires: http://www.tomdeater.com/jquery/onfontresize/


### PR DESCRIPTION
I realize a change event handler is not a silver bullet for handling this, but it should catch auto filling at any time as long as a change event is triggered along with the auto fill. Works with Chrome and LastPass.

Whether or not the change event is fired is up to browser and extension developers. Where the events are not fired, this could be used as a workaround: https://github.com/tbosch/autofill-event

For what it's worth, the WHATWG spec requires user agents to fire the event after auto filling: https://html.spec.whatwg.org/multipage/forms.html#event-input-change (end of chapter).