### PR TITLE
Fix placeholder vertical positioning when text input element height changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 
 /npm-debug.log
+.DS_Store

--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -27,25 +27,24 @@
     }
     function positionPlaceholder(placeholder,input){
         var ta  = input.is('textarea');
-        var pt = parseFloat(input.css('padding-top'));
-        var pl = parseFloat(input.css('padding-left'));
-
-        // Determine if we need to shift the header down more.
-        var offset = input.offset();
-        if (pt) {
-            offset.top += pt;
-        }
-        if (pl) {
-            offset.left += pl;
-        }
 
         placeholder.css({
             width : input.innerWidth()-(ta ? 20 : 4),
-            height : input.innerHeight()-6,
             lineHeight : input.css('line-height'),
             whiteSpace : ta ? 'normal' : 'nowrap',
             overflow : 'hidden'
-        }).offset(offset);
+        })
+
+        var top = parseInt((input.outerHeight() / 2) - (placeholder.outerHeight() / 2));
+        var left = parseFloat(input.css('padding-left'));
+        var offset = input.offset();
+        if (top) {
+            offset.top += top;
+        }
+        if (left) {
+            offset.left += left;
+        }
+        placeholder.offset(offset);
     }
     function startFilledCheckChange(input,options){
         var val = input.val();
@@ -157,18 +156,18 @@
             showPlaceholderIfEmpty(input,o.options);
 
             // reformat on window resize and optional reformat on font resize - requires: http://www.tomdeater.com/jquery/onfontresize/
-            $(document).bind("fontresize resize", function(){
+            $(window).bind("fontresize resize", function(){
                 positionPlaceholder(placeholder,input);
             });
 
             // optional reformat when a textarea is being resized - requires http://benalman.com/projects/jquery-resize-plugin/
             if($.event.special.resize){
                 $("textarea").bind("resize", function(event){
-					if ($(this).is(":visible")) {
-						positionPlaceholder(placeholder,input);
-					}
-					event.stopPropagation();
-					event.preventDefault();
+                    if ($(this).is(":visible")) {
+                        positionPlaceholder(placeholder,input);
+                    }
+                    event.stopPropagation();
+                    event.preventDefault();
                 });
             }else{
                 // we simply disable the resizeablilty of textareas when we can't react on them resizing

--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -155,9 +155,11 @@
                 showPlaceholderIfEmpty($(this),o.options);
             });
             showPlaceholderIfEmpty(input,o.options);
-
-            // reformat on window resize and optional reformat on font resize - requires: http://www.tomdeater.com/jquery/onfontresize/
-            $(window).bind("fontresize resize", function(){
+            $(window).bind("resize", function(){
+                positionPlaceholder(placeholder,input);
+            });
+            //optional reformat on font resize - requires: http://www.tomdeater.com/jquery/onfontresize/
+            $(document).bind("fontresize", function(){
                 positionPlaceholder(placeholder,input);
             });
 

--- a/src/placeholder_polyfill.jquery.js
+++ b/src/placeholder_polyfill.jquery.js
@@ -30,6 +30,7 @@
 
         placeholder.css({
             width : input.innerWidth()-(ta ? 20 : 4),
+            height : ta ? input.innerHeight() - 6 : 'auto',
             lineHeight : input.css('line-height'),
             whiteSpace : ta ? 'normal' : 'nowrap',
             overflow : 'hidden'


### PR DESCRIPTION
This fixes a positioning issue with responsive layouts which change the height of single line text input boxes dynamically based on window size. 

Placeholder span is now positioned vertically in the middle of the input box based on outerHeights instead of basing the positioning on the input box top padding.

Resize event wasn't firing on the `document` object, so bound the handler to `window` instead.
